### PR TITLE
Work

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -19,6 +19,18 @@ public abstract class Book implements StoreMediaOperations {
         this.author = anotherBook.author;
     }
 
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {

--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -44,16 +44,7 @@ public abstract class Book implements StoreMediaOperations {
         Book theOtherBook = (Book) obj;
 
 
-        // bug is here
-        // Quiz: add unit tests to catch this bug.
-        // The bug is caught when
-        //  1. newly add tests fail while all old tests still pass
-        //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
 
-        // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -19,6 +19,18 @@ public abstract class Movie implements StoreMediaOperations {
         this.id = anotherMovie.id;
     }
 
+    public void setRating(String rating) {
+        this.rating = rating;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -44,16 +44,7 @@ public abstract class Movie implements StoreMediaOperations {
 
         Movie theOtherMovie = (Movie) obj;
 
-        // bug is here
-        // Quiz: add unit tests to catch this bug.
-        // The bug is caught when
-        //  1. newly add tests fail while all old tests still pass
-        //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
 
-        // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -14,6 +14,8 @@ public class Problem3Test {
         b_other.setTitle("t2");
         //should fail this as we havent implemented the fix yet
         assertTrue(b.equals(b_other));
+        //ids are different, should return false.
+        assertFalse(b.equals(new BookFiction("t1","au1","g1")));
     }
 
     @Test
@@ -26,6 +28,8 @@ public class Problem3Test {
         m_other.setTitle("t2");
         //should fail this as we havent implemented the fix yet
         assertTrue(m.equals(m_other));
+        //ids are different, should return false.
+        assertFalse(m.equals(new MovieAction("pg13", "jason bourne")));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -6,12 +6,26 @@ import static org.junit.Assert.*;
 public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
-        // quiz
+        BookFiction b = new BookFiction("t1", "au1", "g1");
+        BookFiction b_other = new BookFiction(b);
+        //should pass this as we havent changed title, author
+        assertTrue(b.equals(b_other));
+        b_other.setAuthor("au2");
+        b_other.setTitle("t2");
+        //should fail this as we havent implemented the fix yet
+        assertTrue(b.equals(b_other));
     }
 
     @Test
     public void catchTheBugInMovie() {
-        // quiz
+        MovieAction m = new MovieAction("pg13", "jason bourne");
+        MovieAction m_other = new MovieAction(m);
+        //should pass this as we havent changed rating, title
+        assertTrue(m.equals(m_other));
+        m_other.setRating("au2");
+        m_other.setTitle("t2");
+        //should fail this as we havent implemented the fix yet
+        assertTrue(m.equals(m_other));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
The tests can still pass with this bug in effect because the tests were originally checking if the equals method was returning true for two books/movies where one was created using the copy constructor, and if the equals method returned false for a book/movie created using "new" instead of the copy constructor. With the copy constructor, all the parameters were being copied, the id, and the title/genre/rating/author. The spec stated that the movies and books are considered equal if the ID were the same and nothing else mattered, but the tests didnt make this special check because when the tests were supposed to pass, the id was copied by the copy constructor, which is a good thing, but the rest of the parameters were coincidentally also copied. The test case was designed to check if the equals method returned false when there was a new object, which changes the ID. But the test case never tested the case in which a copy constructor was used to conserve the ID, but the rest of the variables were changed. This is still supposed to return true, but with the buggy implementation, it would actually return false if any of the other variables were changed.